### PR TITLE
Get reasonable outputs

### DIFF
--- a/algorithm/algorithm.go
+++ b/algorithm/algorithm.go
@@ -145,7 +145,7 @@ func (t *TradingAlgorithm) Trade(date time.Time) error {
 
 // Format helpers for debug headers.
 func signalHeader(signal, header string) string {
-	return fmt.Sprintf("signalstrat.%s.%s", signal, header)
+	return fmt.Sprintf("signal.%s.%s", signal, header)
 }
 func stratHeader(strat, header string) string { return fmt.Sprintf("strat.%s.%s", strat, header) }
 func algHeader(header string) string          { return fmt.Sprintf("alg.%s", header) }

--- a/db/dailyprices/dailyprices.go
+++ b/db/dailyprices/dailyprices.go
@@ -1,3 +1,4 @@
 package dailyprices
 
+// Name of the dailyprices store.
 const Name = "dailyprices"

--- a/db/dailyprices/inmemory.go
+++ b/db/dailyprices/inmemory.go
@@ -7,24 +7,25 @@ import (
 	"github.com/d-sparks/gravy/db"
 )
 
-// Serves prices from local memory.
+// InMemoryStore serves prices from local memory.
 type InMemoryStore struct {
 	data  map[time.Time]*db.Data
 	dates []time.Time
 }
 
+// NewInMemoryStore returns a new InMemoryStore with empty data.
 func NewInMemoryStore() *InMemoryStore {
 	return &InMemoryStore{data: map[time.Time]*db.Data{}}
 }
 
-// Not yet implemented.
+// NewInMemoryStoreFromFile is not yet implemented.
 func NewInMemoryStoreFromFile(filename string) *InMemoryStore {
 	store := InMemoryStore{data: map[time.Time]*db.Data{}}
 	// TODO(dansparks): This will essentially be kaggle/pipeline.go.
 	return &store
 }
 
-// Return prices for the given date.
+// Get returns prices for the given date.
 func (i *InMemoryStore) Get(date time.Time) (*db.Data, error) {
 	data, ok := i.data[date]
 	if !ok {
@@ -33,7 +34,7 @@ func (i *InMemoryStore) Get(date time.Time) (*db.Data, error) {
 	return data, nil
 }
 
-// Add the date to the store. Dates should be added in sequential order.
+// Set adds the date to the store. Dates should be added in sequential order.
 func (i *InMemoryStore) Set(date time.Time, data *db.Data) {
 	i.data[date] = data
 	i.dates = append(i.dates, date)

--- a/db/dailyprices/inmemory.go
+++ b/db/dailyprices/inmemory.go
@@ -2,6 +2,7 @@ package dailyprices
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/d-sparks/gravy/db"
@@ -9,20 +10,60 @@ import (
 
 // InMemoryStore serves prices from local memory.
 type InMemoryStore struct {
-	data  map[time.Time]*db.Data
-	dates []time.Time
+	data                map[time.Time]*db.Data
+	dates               []time.Time
+	nextDates           map[time.Time]time.Time
+	nextDatesCalculated bool
 }
 
 // NewInMemoryStore returns a new InMemoryStore with empty data.
 func NewInMemoryStore() *InMemoryStore {
-	return &InMemoryStore{data: map[time.Time]*db.Data{}}
+	return &InMemoryStore{
+		data:                map[time.Time]*db.Data{},
+		dates:               []time.Time{},
+		nextDates:           map[time.Time]time.Time{},
+		nextDatesCalculated: false,
+	}
 }
 
 // NewInMemoryStoreFromFile is not yet implemented.
 func NewInMemoryStoreFromFile(filename string) *InMemoryStore {
-	store := InMemoryStore{data: map[time.Time]*db.Data{}}
+	store := NewInMemoryStore()
 	// TODO(dansparks): This will essentially be kaggle/pipeline.go.
-	return &store
+	return store
+}
+
+// ValidDate implements db interface and returns whether the date is valid.
+func (i *InMemoryStore) ValidDate(date time.Time) (bool, error) {
+	_, ok := i.data[date]
+	return ok, nil
+}
+
+// NextDate returns the next date. Calls calculate next dates if it hasn't been called.
+func (i *InMemoryStore) NextDate(date time.Time) (*time.Time, error) {
+	if valid, err := i.ValidDate(date); err != nil {
+		return nil, err
+	} else if valid {
+		if !i.nextDatesCalculated {
+			i.calculateNextDates()
+		}
+		nextDate, ok := i.nextDates[date]
+		if !ok {
+			return nil, fmt.Errorf("No next date")
+		}
+		return &nextDate, nil
+	}
+	// Brute force!
+	var nextDate *time.Time = nil
+	for _, otherDate := range i.dates {
+		if nextDate == nil || (otherDate.After(date) && nextDate.After(otherDate)) {
+			nextDate = &otherDate
+		}
+	}
+	if nextDate == nil {
+		return nil, fmt.Errorf("No next date")
+	}
+	return nextDate, nil
 }
 
 // Get returns prices for the given date.
@@ -38,4 +79,22 @@ func (i *InMemoryStore) Get(date time.Time) (*db.Data, error) {
 func (i *InMemoryStore) Set(date time.Time, data *db.Data) {
 	i.data[date] = data
 	i.dates = append(i.dates, date)
+	i.nextDatesCalculated = false
+}
+
+// calculateNextDates calcultes the date after each date. Not part of db interface.
+func (i *InMemoryStore) calculateNextDates() {
+	i.nextDates = map[time.Time]time.Time{}
+	dateStrs := sort.StringSlice{}
+	parsed := map[string]time.Time{}
+	for _, date := range i.dates {
+		dateStr := date.Format("2006-01-02")
+		dateStrs = append(dateStrs, dateStr)
+		parsed[dateStr] = date
+	}
+	dateStrs.Sort()
+	for ix := 1; ix < len(dateStrs); ix++ {
+		i.nextDates[parsed[dateStrs[ix-1]]] = parsed[dateStrs[ix]]
+	}
+	i.nextDatesCalculated = true
 }

--- a/db/dailyprices/inmemory_test.go
+++ b/db/dailyprices/inmemory_test.go
@@ -1,0 +1,68 @@
+package dailyprices
+
+import (
+	"testing"
+	"time"
+
+	"github.com/d-sparks/gravy/db"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInMemoryStoreValidDate(t *testing.T) {
+	store := NewInMemoryStore()
+	data := db.Data{}
+	date, err := time.Parse("2006-01-02", "2020-01-01")
+	assert.NoError(t, err)
+	store.Set(date, &data)
+
+	date2, err := time.Parse("2006-01-02", "2020-01-02")
+	assert.NoError(t, err)
+
+	dateValid, err := store.ValidDate(date)
+	assert.NoError(t, err)
+	assert.True(t, dateValid)
+
+	date2Valid, err := store.ValidDate(date2)
+	assert.NoError(t, err)
+	assert.False(t, date2Valid)
+}
+
+func TestInMemoryStoreNextDate(t *testing.T) {
+	store := NewInMemoryStore()
+	data := db.Data{}
+
+	date1, err := time.Parse("2006-01-02", "2020-01-01")
+	assert.NoError(t, err)
+	date2, err := time.Parse("2006-01-02", "2020-01-02")
+	assert.NoError(t, err)
+	date3, err := time.Parse("2006-01-02", "2020-01-03")
+	assert.NoError(t, err)
+
+	store.Set(date1, &data)
+	store.Set(date3, &data)
+
+	date1NextDate, err := store.NextDate(date1)
+	assert.NoError(t, err)
+	assert.Equal(t, date3, *date1NextDate)
+
+	date2NextDate, err := store.NextDate(date2)
+	assert.NoError(t, err)
+	assert.Equal(t, date3, *date2NextDate)
+
+	_, err = store.NextDate(date3)
+	assert.Error(t, err)
+}
+
+func TestInMemoryStoreGet(t *testing.T) {
+	store := NewInMemoryStore()
+	data := db.Data{}
+
+	date1, err := time.Parse("2006-01-02", "2020-01-01")
+	assert.NoError(t, err)
+
+	store.Set(date1, &data)
+
+	retrieved, err := store.Get(date1)
+	assert.NoError(t, err)
+	assert.Equal(t, &data, retrieved)
+}

--- a/db/dailyprices/postgres_test.go
+++ b/db/dailyprices/postgres_test.go
@@ -1,0 +1,90 @@
+package dailyprices
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	dbURL       = "postgres://localhost/gravy?sslmode=disable"
+	pricesTable = "dailyprices"
+	datesTable  = "tradingdates"
+)
+
+func getDB(t *testing.T) *PostgresStore {
+	store, err := NewPostgresStore(dbURL, pricesTable, datesTable)
+	assert.NoError(t, err)
+	return store
+}
+
+func TestPostgresStoreValidDate(t *testing.T) {
+	store := getDB(t)
+	defer store.Close()
+
+	jan3, err := time.Parse("2006-01-02", "2010-01-03")
+	assert.NoError(t, err)
+	jan4, err := time.Parse("2006-01-02", "2010-01-04")
+	assert.NoError(t, err)
+
+	jan3Valid, err := store.ValidDate(jan3)
+	assert.NoError(t, err)
+	assert.False(t, jan3Valid)
+
+	jan4Valid, err := store.ValidDate(jan4)
+	assert.NoError(t, err)
+	assert.True(t, jan4Valid)
+}
+
+func TestPostgresStoreNextDate(t *testing.T) {
+	store := getDB(t)
+	defer store.Close()
+
+	dec31, err := time.Parse("2006-01-02", "2009-12-31")
+	assert.NoError(t, err)
+	jan3, err := time.Parse("2006-01-02", "2010-01-03")
+	assert.NoError(t, err)
+	jan4, err := time.Parse("2006-01-02", "2010-01-04")
+	assert.NoError(t, err)
+	jan5, err := time.Parse("2006-01-02", "2010-01-05")
+	assert.NoError(t, err)
+	future, err := time.Parse("2006-01-02", "2112-01-01")
+	assert.NoError(t, err)
+
+	dec31Next, err := store.NextDate(dec31)
+	assert.NoError(t, err)
+	jan3Next, err := store.NextDate(jan3)
+	assert.NoError(t, err)
+	jan4Next, err := store.NextDate(jan4)
+	assert.NoError(t, err)
+
+	assert.Equal(t, jan4, *dec31Next)
+	assert.Equal(t, jan4, *jan3Next)
+	assert.Equal(t, jan5, *jan4Next)
+
+	_, err = store.NextDate(future)
+	assert.Error(t, err)
+}
+
+func TestPostgresStoreGet(t *testing.T) {
+	store := getDB(t)
+	defer store.Close()
+
+	jan4, err := time.Parse("2006-01-02", "2010-01-04")
+	assert.NoError(t, err)
+	data, err := store.Get(jan4)
+	assert.NoError(t, err)
+
+	//  ticker | open  | close | adj_close |  low  | high |   volume    |    date
+	// --------+-------+-------+-----------+-------+------+-------------+------------
+	//  MSFT   | 30.62 | 30.95 | 24.827723 | 30.59 | 31.1 | 3.84091e+07 | 2010-01-04
+
+	prices := data.TickersToPrices["MSFT"]
+	assert.Equal(t, 30.62, prices.Open)
+	assert.Equal(t, 30.95, prices.Close)
+	assert.Equal(t, 24.827723, prices.AdjClose)
+	assert.Equal(t, 30.59, prices.Low)
+	assert.Equal(t, 31.1, prices.High)
+	assert.Equal(t, 3.84091e+07, prices.Volume)
+}

--- a/db/db.go
+++ b/db/db.go
@@ -12,7 +12,9 @@ type Data struct {
 }
 
 type Store interface {
+	ValidDate(date time.Time) (bool, error)
 	Get(date time.Time) (*Data, error)
+	NextDate(date time.Time) (*time.Time, error)
 }
 
 type Prices struct {

--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,12 @@ go 1.12
 
 require (
 	github.com/Clever/go-utils v0.0.0-20180917210021-2dac0ec6f2ac
-	github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac // indirect
-	github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82 // indirect
 	github.com/gonum/integrate v0.0.0-20181209220457-a422b5c0fdf2 // indirect
-	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
-	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
-	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 // indirect
 	github.com/gonum/stat v0.0.0-20181125101827-41a0da705a5b
 	github.com/lib/pq v1.3.0
 	github.com/montanaflynn/stats v0.5.0
 	github.com/spf13/cobra v0.0.5
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/perf v0.0.0-20191209155426-36b577b0eb03
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -53,8 +54,13 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/metric/ndayperf/ndayperf.go
+++ b/metric/ndayperf/ndayperf.go
@@ -10,53 +10,69 @@ import (
 	"github.com/d-sparks/gravy/strategy"
 )
 
+// Name of the ndayperf metric.
 func Name(days int) string { return fmt.Sprintf("%ddayperf", days) }
 
-// Performance over N days.
+// NDayPerf is the performance over N days.
 type NDayPerf struct {
 	days int
 }
 
+// New NDayPerf strategy.
 func New(days int) *NDayPerf {
 	return &NDayPerf{days}
 }
 
-// Return the name for this metric.
+// Name as per the metric interface.
 func (n *NDayPerf) Name() string {
 	return Name(n.days)
 }
 
+// Value of the metric is the rate of return of a capital distribution over N days. That is
+//
+//   \sum_ticker probability(ticker) * close(ticker, today + N) / open(ticker, today + 1)
+//
+// This is a percentage and can be positive or negative. The question of what to do when tickers from today + 1 are not
+// still listed at today + N is left open. For now, for such stocks we assume a neutral rate of return.
 func (n *NDayPerf) Value(
 	date time.Time,
 	stores map[string]db.Store,
 	signals map[string]signal.Signal,
 	strategyOutput *strategy.StrategyOutput,
 ) (float64, error) {
-	// Get today's prices.
-	todayPricesData, err := stores[dailyprices.Name].Get(date)
+	// Get tomorrow's prices.
+	nextTradingDay, err := stores[dailyprices.Name].NextDate(date)
 	if err != nil {
-		fmt.Errorf("Error getting todays prices in  `%s`: `%s`", n.Name(), err.Error())
+		return 0.0, fmt.Errorf("Couldn't get nextTradingDay in `%s`: `%s`", n.Name(), err.Error())
+	}
+	tomorrowPricesData, err := stores[dailyprices.Name].Get(*nextTradingDay)
+	if err != nil {
+		return 0.0, fmt.Errorf("Error getting todays prices in  `%s`: `%s`", n.Name(), err.Error())
 	}
 
-	// Get prices after n days.
-	endDate := date.AddDate(0, 0, n.days)
-	endPricesData, err := stores[dailyprices.Name].Get(endDate)
+	// Get prices after n days. The minus one is because NextDate will also increase by at least 1.
+	endDate := date.AddDate(0, 0, n.days-1)
+	endTradingDate, err := stores[dailyprices.Name].NextDate(endDate)
 	if err != nil {
-		fmt.Errorf("Error getting end prices in `%s`: `%s`", n.Name(), err.Error())
+		return 0.0, fmt.Errorf("Couldn't get nDay trading date in `%s`: `%s`", n.Name(), err.Error())
+	}
+	endPricesData, err := stores[dailyprices.Name].Get(*endTradingDate)
+	if err != nil {
+		return 0.0, fmt.Errorf("Error getting end prices in `%s`: `%s`", n.Name(), err.Error())
 	}
 
 	// Calculate rate of return of each stock in the portfolio.
 	cd := strategyOutput.CapitalDistribution
 	overallReturn := 0.0
-	for ticker, _ := range cd.NonZeroStocks {
-		todayPrices, ok := todayPricesData.TickersToPrices[ticker]
+	for ticker := range cd.NonZeroStocks {
+		tomorrowPrices, ok := tomorrowPricesData.TickersToPrices[ticker]
 		if !ok {
-			return 0.0, fmt.Errorf("No opening price for `%s` in metric `%s`: `%s`", ticker, n.Name())
+			return 0.0, fmt.Errorf("No opening price for `%s` in metric `%s`", ticker, n.Name())
 		}
 
 		endPrices, ok := endPricesData.TickersToPrices[ticker]
 		if ok {
-			overallReturn += cd.GetStock(ticker) * (endPrices.Close / todayPrices.Close)
+			overallReturn += cd.GetStock(ticker) * (endPrices.Close / tomorrowPrices.Open)
 		} else {
 			// If there is no closing price assume a neutral return. (This might be a bad assumption.)
 			overallReturn += cd.GetStock(ticker) // * 1.0

--- a/signal/ipos/ipos.go
+++ b/signal/ipos/ipos.go
@@ -4,45 +4,52 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Clever/go-utils/stringset"
 	"github.com/d-sparks/gravy/db"
 	"github.com/d-sparks/gravy/db/dailyprices"
 	"github.com/d-sparks/gravy/signal"
 )
 
+// Name of the ipos signal.
 const Name = "ipos"
 
-// IPOs reports tickers not present in the last daily prices.
-type IPOs struct {
-	previousTickers stringset.StringSet
-}
+// IPOs returns symbols which will be be IPOing on the NEXT trading day.
+type IPOs struct{}
 
+// New cached IPOs.
 func New() *signal.CachedSignal {
-	return signal.NewCachedSignal(
-		&IPOs{previousTickers: stringset.StringSet{}},
-		time.Hour*24*365, // one year
-	)
+	return signal.NewCachedSignal(&IPOs{}, time.Hour*24*365)
 }
 
+// Name returns the ipos signal name, for the signal interface.
 func (i *IPOs) Name() string {
 	return Name
 }
 
-// Diffs tickers reported by dailyprices with that seen in the previous computation.
+// Compute computes the signal as per the signal interface.
 func (i *IPOs) Compute(date time.Time, stores map[string]db.Store) (*signal.SignalOutput, error) {
-	dailyPrices, err := stores[dailyprices.Name].Get(date)
+	todayData, err := stores[dailyprices.Name].Get(date)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading dailyprices in `%s`: `%s`", Name, err.Error())
+		return nil, fmt.Errorf("Error reading todayprices in `%s`: `%s`", Name, err.Error())
 	}
-	output := signal.SignalOutput{StringSet: dailyPrices.Tickers.Minus(i.previousTickers)}
-	i.previousTickers = dailyPrices.Tickers
-	return &output, nil
+
+	tomorrowDate, err := stores[dailyprices.Name].NextDate(date)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting next date in `%s`: `%s`", Name, err.Error())
+	}
+
+	tomorrowData, err := stores[dailyprices.Name].Get(*tomorrowDate)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting tomorrowprices in `%s`: `%s`", Name, err.Error())
+	}
+	return &signal.SignalOutput{StringSet: tomorrowData.Tickers.Minus(todayData.Tickers)}, nil
 }
 
+// Headers as per signal interface.
 func (i *IPOs) Headers() []string {
 	return []string{}
 }
 
+// Debug as per signal interface.
 func (i *IPOs) Debug() map[string]string {
 	return map[string]string{}
 }

--- a/signal/ipos/ipos_test.go
+++ b/signal/ipos/ipos_test.go
@@ -11,28 +11,31 @@ import (
 )
 
 func TestIPOs(t *testing.T) {
-	yesterdayTime, err := time.Parse("2006-01-02", "2004-08-18")
+	todayTime, err := time.Parse("2006-01-02", "2004-08-18")
 	assert.NoError(t, err)
-	todayTime, err := time.Parse("2006-01-02", "2004-08-19")
+	tomorrowTime, err := time.Parse("2006-01-02", "2004-08-19")
+	assert.NoError(t, err)
+	twoDaysTime, err := time.Parse("2006-01-02", "2004-08-19")
 	assert.NoError(t, err)
 
-	yesterday := db.Data{Tickers: stringset.New("MSFT")}
-	today := db.Data{Tickers: stringset.New("MSFT", "GOOGL")}
+	today := db.Data{Tickers: stringset.New("MSFT")}
+	tomorrow := db.Data{Tickers: stringset.New("MSFT", "GOOGL")}
 
 	testStore := dailyprices.NewInMemoryStore()
-	testStore.Set(yesterdayTime, &yesterday)
 	testStore.Set(todayTime, &today)
+	testStore.Set(tomorrowTime, &tomorrow)
+	testStore.Set(twoDaysTime, &tomorrow)
 
 	stores := map[string]db.Store{}
 	stores[dailyprices.Name] = testStore
 
 	ipos := New()
 
-	yesterdayOutput, err := ipos.Compute(yesterdayTime, stores)
-	assert.NoError(t, err)
-	assert.True(t, yesterdayOutput.StringSet.Equals(stringset.New("MSFT")))
-
 	todayOutput, err := ipos.Compute(todayTime, stores)
 	assert.NoError(t, err)
 	assert.True(t, todayOutput.StringSet.Equals(stringset.New("GOOGL")))
+
+	tomorrowOutput, err := ipos.Compute(tomorrowTime, stores)
+	assert.NoError(t, err)
+	assert.True(t, tomorrowOutput.StringSet.Equals(stringset.New()))
 }

--- a/signal/unlistings/unlistings.go
+++ b/signal/unlistings/unlistings.go
@@ -4,44 +4,52 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Clever/go-utils/stringset"
 	"github.com/d-sparks/gravy/db"
 	"github.com/d-sparks/gravy/db/dailyprices"
 	"github.com/d-sparks/gravy/signal"
 )
 
+// Name of the unlistings signal.
 const Name = "unlistings"
 
-// Unlistings reports new values since last tick.
-type Unlistings struct {
-	previousTickers stringset.StringSet
-}
+// Unlistings reports tickers that will not be listed tomorrow.
+type Unlistings struct{}
 
+// New cached Unlistings.
 func New() *signal.CachedSignal {
-	return signal.NewCachedSignal(
-		&Unlistings{previousTickers: stringset.StringSet{}},
-		time.Hour*24*365,
-	)
+	return signal.NewCachedSignal(&Unlistings{}, time.Hour*24*365)
 }
 
+// Name returns the name of Unlistings as per the signal interface.
 func (u *Unlistings) Name() string {
 	return Name
 }
 
+// Compute computes the signal as per the signal interface.
 func (u *Unlistings) Compute(date time.Time, stores map[string]db.Store) (*signal.SignalOutput, error) {
-	data, err := stores[dailyprices.Name].Get(date)
+	todayData, err := stores[dailyprices.Name].Get(date)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading dailyprices in `%s`: `%s`", Name, err.Error())
+		return nil, fmt.Errorf("Error reading todayprices in `%s`: `%s`", Name, err.Error())
 	}
-	output := signal.SignalOutput{StringSet: u.previousTickers.Minus(data.Tickers)}
-	u.previousTickers = data.Tickers
-	return &output, nil
+
+	tomorrowDate, err := stores[dailyprices.Name].NextDate(date)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting next date in `%s`: `%s`", Name, err.Error())
+	}
+
+	tomorrowData, err := stores[dailyprices.Name].Get(*tomorrowDate)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting tomorrowprices in `%s`: `%s`", Name, err.Error())
+	}
+	return &signal.SignalOutput{StringSet: todayData.Tickers.Minus(tomorrowData.Tickers)}, nil
 }
 
+// Headers as per signal interface.
 func (u *Unlistings) Headers() []string {
 	return []string{}
 }
 
+// Debug as per signal interface.
 func (u *Unlistings) Debug() map[string]string {
 	return map[string]string{}
 }

--- a/signal/unlistings/unlistings_test.go
+++ b/signal/unlistings/unlistings_test.go
@@ -11,28 +11,31 @@ import (
 )
 
 func TestUnlistings(t *testing.T) {
-	yesterdayTime, err := time.Parse("2006-01-02", "2013-10-28")
+	todayTime, err := time.Parse("2006-01-02", "2013-10-28")
 	assert.NoError(t, err)
-	todayTime, err := time.Parse("2006-01-02", "2013-10-29")
+	tomorrowTime, err := time.Parse("2006-01-02", "2013-10-29")
+	assert.NoError(t, err)
+	twoDaysTime, err := time.Parse("2006-01-02", "2013-10-29")
 	assert.NoError(t, err)
 
 	yesterday := db.Data{Tickers: stringset.New("GOOGL", "DELL")}
 	today := db.Data{Tickers: stringset.New("GOOGL")}
 
 	testStore := dailyprices.NewInMemoryStore()
-	testStore.Set(yesterdayTime, &yesterday)
-	testStore.Set(todayTime, &today)
+	testStore.Set(todayTime, &yesterday)
+	testStore.Set(tomorrowTime, &today)
+	testStore.Set(twoDaysTime, &today)
 
 	stores := map[string]db.Store{}
 	stores[dailyprices.Name] = testStore
 
 	unlistings := New()
 
-	yesterdayOutput, err := unlistings.Compute(yesterdayTime, stores)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(yesterdayOutput.StringSet))
-
 	todayOutput, err := unlistings.Compute(todayTime, stores)
 	assert.NoError(t, err)
 	assert.True(t, todayOutput.StringSet.Equals(stringset.New("DELL")))
+
+	tomorrowOutput, err := unlistings.Compute(tomorrowTime, stores)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(tomorrowOutput.StringSet))
 }

--- a/strategy/buyandhold/buyandhold.go
+++ b/strategy/buyandhold/buyandhold.go
@@ -13,26 +13,30 @@ import (
 	"github.com/d-sparks/gravy/trading"
 )
 
+// Name of the buyandhold strategy.
 const Name = "buyandhold"
 
 // BuyAndHold strategy. Invest equally in all securities. When there is an IPO or unlisting.
 type BuyAndHold struct {
 	abstractPortfolio *trading.AbstractPortfolio
+	previousIPOs      bool
 	debug             map[string]string
 }
 
+// New BuyAndHold strategy.
 func New() *BuyAndHold {
-	return &BuyAndHold{}
+	return &BuyAndHold{abstractPortfolio: nil, previousIPOs: false, debug: map[string]string{}}
 }
 
+// Name returns the name as per the strategy interface.
 func (b *BuyAndHold) Name() string {
 	return Name
 }
 
-// Whenever there is an ipo or unlisting, invest equally in all securities. This is achieved by taking a uniform
-// capital distribution and turning it into an abstract portfolio worth $1.0 on the most recent closing prices. This
-// portfolio is memorized until the next ipo or unlisting. On any other day, we imagine having held that original
-// abstract portfolio and recommend a capital distribution that replicates that portfolio at the most recent prices.
+// Run the strategy. In the first run, when there is an unlisting, or the session after an IPO signal, create an
+// abstract portfolio invested uniformly in (tomorrow's tickers) \bigcap (today's tickers) based on today's prices.
+// "Hold" this abstract portfolio by returning a capital distribution that is the distribution of the mature value of
+// the portfolio.
 func (b *BuyAndHold) Run(
 	date time.Time,
 	stores map[string]db.Store,
@@ -40,36 +44,46 @@ func (b *BuyAndHold) Run(
 ) (*strategy.StrategyOutput, error) {
 	b.debug = map[string]string{}
 
-	iposData, err := signals[ipos.Name].Compute(date, stores)
-	if err != nil {
-		return nil, fmt.Errorf("Error computing ipos in strategy `%s`: `%s`", Name, err.Error())
-	}
+	// Get unlistings and prices.
 	unlistingsData, err := signals[unlistings.Name].Compute(date, stores)
 	if err != nil {
 		return nil, fmt.Errorf("Error computing unlistings in strategy `%s`: `%s`", Name, err.Error())
 	}
-	dailyPricesData, err := stores[dailyprices.Name].Get(date)
+	pricesData, err := stores[dailyprices.Name].Get(date)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting daily prices in strategy `%s`: `%s`", Name, err.Error())
 	}
 
-	if b.abstractPortfolio == nil || len(iposData.StringSet) > 0 || len(unlistingsData.StringSet) > 0 {
-		uniform := trading.NewUniformCapitalDistribution(dailyPricesData.Tickers)
-		b.abstractPortfolio = uniform.ToAbstractPortfolioOnClose(dailyPricesData.TickersToPrices, 1.0)
+	// If we need to rebalance our portfolio, do so.
+	if b.abstractPortfolio == nil || b.previousIPOs || len(unlistingsData.StringSet) > 0 {
+		investIn := pricesData.Tickers
+		for ticker := range unlistingsData.StringSet {
+			investIn.Remove(ticker)
+		}
+		uniform := trading.NewUniformCapitalDistribution(investIn)
+		b.abstractPortfolio = uniform.ToAbstractPortfolioOnClose(pricesData.TickersToPrices, 1.0)
 	}
 
+	// If there were IPOs, remember this so we can rebalance in the next session.
+	iposData, err := signals[ipos.Name].Compute(date, stores)
+	if err != nil {
+		return nil, fmt.Errorf("Error computing ipos in strategy `%s`: `%s`", Name, err.Error())
+	}
+	b.previousIPOs = len(iposData.StringSet) > 0
+
+	// Return a capital distribution corresponding to the mature value of the abstract portfolio.
 	strategyOutput := strategy.StrategyOutput{
-		CapitalDistribution: b.abstractPortfolio.ToCapitalDistributionOnClose(dailyPricesData.TickersToPrices),
+		CapitalDistribution: b.abstractPortfolio.ToCapitalDistributionOnClose(pricesData.TickersToPrices),
 	}
 	return &strategyOutput, nil
 }
 
-// No data to output
+// Headers as per the strategy interface.
 func (b *BuyAndHold) Headers() []string {
 	return []string{}
 }
 
-// Return last run's debug.
+// Debug as per the strategy interface.
 func (b *BuyAndHold) Debug() map[string]string {
 	return b.debug
 }

--- a/strategy/buyandhold/buyandhold_test.go
+++ b/strategy/buyandhold/buyandhold_test.go
@@ -1,0 +1,93 @@
+package buyandhold
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Clever/go-utils/stringset"
+	"github.com/d-sparks/gravy/db"
+	"github.com/d-sparks/gravy/db/dailyprices"
+	"github.com/d-sparks/gravy/signal"
+	"github.com/d-sparks/gravy/signal/ipos"
+	"github.com/d-sparks/gravy/signal/unlistings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuyAndHoldExample(t *testing.T) {
+	// Load some simple fake data.
+	store := dailyprices.NewInMemoryStore()
+	parsed := map[string]time.Time{}
+	pricesMap := map[string]map[string]float64{
+		"2020-01-01": map[string]float64{"MSFT": 1.0},
+		"2020-01-02": map[string]float64{"MSFT": 2.0},
+		"2020-01-03": map[string]float64{"MSFT": 1.0, "GOOGL": 1.0},
+		"2020-01-04": map[string]float64{"MSFT": 1.0, "GOOGL": 2.0},
+		"2020-01-05": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0},
+		"2020-01-06": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0, "FB": 2.0},
+		"2020-01-07": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0, "FB": 4.0},
+		"2020-01-08": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0, "FB": 4.0},
+	}
+	for dateStr, prices := range pricesMap {
+		date, err := time.Parse("2006-01-02", dateStr)
+		assert.NoError(t, err)
+		data := db.Data{Tickers: stringset.New(), TickersToPrices: map[string]db.Prices{}}
+		for ticker, price := range prices {
+			data.Tickers.Add(ticker)
+			data.TickersToPrices[ticker] = db.Prices{Close: price}
+		}
+		store.Set(date, &data)
+		parsed[dateStr] = date
+	}
+
+	// Create inputs necessary for strategy.
+	stores := map[string]db.Store{}
+	stores[dailyprices.Name] = store
+	signals := map[string]signal.Signal{}
+	signals[ipos.Name] = ipos.New()
+	signals[unlistings.Name] = unlistings.New()
+
+	// Run strategy on given dates.
+	b := New()
+
+	// In the first window, should invest everything in MSFT.
+	output, err := b.Run(parsed["2020-01-01"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, output.CapitalDistribution.GetStock("MSFT"))
+
+	// Second window we are still all-in on MSFT.
+	output, err = b.Run(parsed["2020-01-02"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, output.CapitalDistribution.GetStock("MSFT"))
+
+	// Third window we rebalance to be equal in MSFT and GOOGL.
+	output, err = b.Run(parsed["2020-01-03"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("MSFT"))
+	assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("GOOGL"))
+
+	// Fourth window it's as if we hold one unit of MSFT and one unit of GOOGL.
+	output, err = b.Run(parsed["2020-01-04"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("MSFT"))
+	assert.Equal(t, 2.0/3.0, output.CapitalDistribution.GetStock("GOOGL"))
+
+	// Fifth window is still one each of MSFT and GOOGL.
+	output, err = b.Run(parsed["2020-01-05"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("MSFT"))
+	assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("GOOGL"))
+
+	// Sixth window is split between MSFT/GOOGL/FB.
+	output, err = b.Run(parsed["2020-01-06"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("MSFT"))
+	assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("GOOGL"))
+	assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("FB"))
+
+	// Seventh window is as if the 1/3 of our portfolio doubled (FB). Thus half of our wealth is in FB.
+	output, err = b.Run(parsed["2020-01-07"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.25, output.CapitalDistribution.GetStock("MSFT"))
+	assert.Equal(t, 0.25, output.CapitalDistribution.GetStock("GOOGL"))
+	assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("FB"))
+}

--- a/strategy/uniform/uniform.go
+++ b/strategy/uniform/uniform.go
@@ -45,11 +45,6 @@ func (b *Uniform) Run(
 		CapitalDistribution: trading.NewUniformCapitalDistribution(dailyPricesData.Tickers),
 	}
 
-	//fmt.Println("=============================")
-	//for ticker, _ := range strategyOutput.CapitalDistribution.NonZeroStocks {
-	//	fmt.Printf("%s:%f,", ticker, strategyOutput.CapitalDistribution.GetStock(ticker))
-	//}
-
 	return &strategyOutput, nil
 }
 

--- a/strategy/uniform/uniform.go
+++ b/strategy/uniform/uniform.go
@@ -7,10 +7,12 @@ import (
 	"github.com/d-sparks/gravy/db"
 	"github.com/d-sparks/gravy/db/dailyprices"
 	"github.com/d-sparks/gravy/signal"
+	"github.com/d-sparks/gravy/signal/unlistings"
 	"github.com/d-sparks/gravy/strategy"
 	"github.com/d-sparks/gravy/trading"
 )
 
+// Name of the uniform strategy.
 const Name = "uniform"
 
 // Uniform strategy. Invest equally in all securities.
@@ -18,15 +20,18 @@ type Uniform struct {
 	debug map[string]string
 }
 
+// New Uniform strategy.
 func New() *Uniform {
 	return &Uniform{}
 }
 
+// Name as per the strategy interface.
 func (b *Uniform) Name() string {
 	return Name
 }
 
-// Return a uniform capital distribution every day based on the previous close price.
+// Run the strategy. Always returns a capital distribution on (today's stocks) \bigcap (tomorrow's stocks) that is
+// invested equally in all tickers as today's closing prices.
 func (b *Uniform) Run(
 	date time.Time,
 	stores map[string]db.Store,
@@ -34,26 +39,35 @@ func (b *Uniform) Run(
 ) (*strategy.StrategyOutput, error) {
 	b.debug = map[string]string{}
 
-	// Get yesterday's prices.
+	// Get today's prices.
 	dailyPricesData, err := stores[dailyprices.Name].Get(date)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting daily prices in strategy `%s`: `%s`", Name, err.Error())
 	}
 
-	// Create and return a uniform capital distribution.
-	strategyOutput := strategy.StrategyOutput{
-		CapitalDistribution: trading.NewUniformCapitalDistribution(dailyPricesData.Tickers),
+	// Get unlistings.
+	unlistingsData, err := signals[unlistings.Name].Compute(date, stores)
+	if err != nil {
+		return nil, fmt.Errorf("Error computing unlistings in strategy `%s`: `%s`", Name, err.Error())
 	}
 
-	return &strategyOutput, nil
+	// Create uniform capital distribution.
+	investIn := dailyPricesData.Tickers
+	for ticker := range unlistingsData.StringSet {
+		investIn.Remove(ticker)
+	}
+	uniform := trading.NewUniformCapitalDistribution(investIn)
+	output := strategy.StrategyOutput{CapitalDistribution: uniform}
+
+	return &output, nil
 }
 
-// No data to output
+// Headers as per strategy interface.
 func (b *Uniform) Headers() []string {
 	return []string{}
 }
 
-// Return last run's debug.
+// Debug as per strategy interface.
 func (b *Uniform) Debug() map[string]string {
 	return b.debug
 }

--- a/strategy/uniform/uniform_test.go
+++ b/strategy/uniform/uniform_test.go
@@ -1,0 +1,93 @@
+package uniform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Clever/go-utils/stringset"
+	"github.com/d-sparks/gravy/db"
+	"github.com/d-sparks/gravy/db/dailyprices"
+	"github.com/d-sparks/gravy/signal"
+	"github.com/d-sparks/gravy/signal/unlistings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniformExample(t *testing.T) {
+	// Load some simple fake data.
+	store := dailyprices.NewInMemoryStore()
+	parsed := map[string]time.Time{}
+	pricesMap := map[string]map[string]float64{
+		"2020-01-01": map[string]float64{"MSFT": 1.0},
+		"2020-01-02": map[string]float64{"MSFT": 2.0},
+		"2020-01-03": map[string]float64{"MSFT": 1.0, "GOOGL": 1.0},
+		"2020-01-04": map[string]float64{"MSFT": 1.0, "GOOGL": 2.0},
+		"2020-01-05": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0},
+		"2020-01-06": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0, "FB": 2.0},
+		"2020-01-07": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0, "FB": 4.0},
+		"2020-01-08": map[string]float64{"MSFT": 2.0, "GOOGL": 2.0, "FB": 4.0},
+	}
+	for dateStr, prices := range pricesMap {
+		date, err := time.Parse("2006-01-02", dateStr)
+		assert.NoError(t, err)
+		data := db.Data{Tickers: stringset.New(), TickersToPrices: map[string]db.Prices{}}
+		for ticker, price := range prices {
+			data.Tickers.Add(ticker)
+			data.TickersToPrices[ticker] = db.Prices{Close: price}
+		}
+		store.Set(date, &data)
+		parsed[dateStr] = date
+	}
+
+	// Create inputs necessary for strategy.
+	stores := map[string]db.Store{}
+	stores[dailyprices.Name] = store
+	signals := map[string]signal.Signal{}
+	signals[unlistings.Name] = unlistings.New()
+
+	// Run strategy on given dates.
+	b := New()
+
+	// In the first window, should invest everything in MSFT.
+	output, err := b.Run(parsed["2020-01-01"], stores, signals)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, output.CapitalDistribution.GetStock("MSFT"))
+
+	/*
+		// Second window we are still all-in on MSFT.
+		output, err = b.Run(parsed["2020-01-02"], stores, signals)
+		assert.NoError(t, err)
+		assert.Equal(t, 1.0, output.CapitalDistribution.GetStock("MSFT"))
+
+		// Third window we rebalance to be equal in MSFT and GOOGL.
+		output, err = b.Run(parsed["2020-01-03"], stores, signals)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("MSFT"))
+		assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("GOOGL"))
+
+		// Fourth window it's as if we hold one unit of MSFT and one unit of GOOGL.
+		output, err = b.Run(parsed["2020-01-04"], stores, signals)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("MSFT"))
+		assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("GOOGL"))
+
+		// Fifth window is still one each of MSFT and GOOGL.
+		output, err = b.Run(parsed["2020-01-05"], stores, signals)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("MSFT"))
+		assert.Equal(t, 0.5, output.CapitalDistribution.GetStock("GOOGL"))
+
+		// Sixth window is split between MSFT/GOOGL/FB.
+		output, err = b.Run(parsed["2020-01-06"], stores, signals)
+		assert.NoError(t, err)
+		assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("MSFT"))
+		assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("GOOGL"))
+		assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("FB"))
+
+		// Seventh window is as if the 1/3 of our portfolio doubled (FB). Thus half of our wealth is in FB.
+		output, err = b.Run(parsed["2020-01-07"], stores, signals)
+		assert.NoError(t, err)
+		assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("MSFT"))
+		assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("GOOGL"))
+		assert.Equal(t, 1.0/3.0, output.CapitalDistribution.GetStock("FB"))
+	*/
+}

--- a/trading/trading_test.go
+++ b/trading/trading_test.go
@@ -4,76 +4,23 @@ import (
 	"testing"
 
 	"github.com/Clever/go-utils/stringset"
+	"github.com/d-sparks/gravy/db"
 	"github.com/stretchr/testify/assert"
 )
 
-var window Window
-
-func init() {
-	window = Window{
-		Open:    Prices{"MSFT": 1.5, "GOOGL": 2.5},
-		Close:   Prices{"MSFT": 2.5, "GOOGL": 3.5},
-		Low:     Prices{"MSFT": 1.0, "GOOGL": 2.0},
-		High:    Prices{"MSFT": 3.0, "GOOGL": 4.0},
-		Symbols: stringset.New("MSFT", "GOOGL"),
+func TestCapitalDistributionToAbstractPortfolioAndBack(t *testing.T) {
+	tickers := stringset.New("MSFT", "GOOGL", "FB")
+	prices := map[string]db.Prices{
+		"MSFT":  db.Prices{Close: 3.0},
+		"GOOGL": db.Prices{Close: 4.0},
+		"FB":    db.Prices{Close: 2.5},
 	}
-}
 
-func TestWindowMeanHighLowPrice(t *testing.T) {
-	assert.Equal(t, 2.0, window.MeanHighLowPrice("MSFT"))
-	assert.Equal(t, 3.0, window.MeanHighLowPrice("GOOGL"))
-}
+	uniform := NewUniformCapitalDistribution(tickers)
+	ap := uniform.ToAbstractPortfolioOnClose(prices, 1337.0)
+	cd := ap.ToCapitalDistributionOnClose(prices)
+	ap2 := cd.ToAbstractPortfolioOnClose(prices, 1337.0)
 
-func TestPortfolioValue(t *testing.T) {
-	portfolio := NewPortfolio(1.0)
-	portfolio.Stocks["MSFT"] = 2
-	portfolio.Stocks["GOOGL"] = 3
-	assert.Equal(t, 19.0, portfolio.Value(window.High))
-}
-
-func TestPortfolioMeanHighLowValue(t *testing.T) {
-	portfolio := NewPortfolio(1.0)
-	portfolio.Stocks["MSFT"] = 2
-	portfolio.Stocks["GOOGL"] = 3
-	assert.Equal(t, 14.0, portfolio.MeanHighLowValue(window))
-}
-
-func TestAbstractPortfolioValue(t *testing.T) {
-	portfolio := NewAbstractPortfolio(1.0)
-	portfolio.Stocks["MSFT"] = 2.0
-	portfolio.Stocks["GOOGL"] = 3.0
-	assert.Equal(t, 19.0, portfolio.Value(window.High))
-}
-
-func TestAbstractPortfolioMeanHighLowValue(t *testing.T) {
-	portfolio := NewAbstractPortfolio(1.0)
-	portfolio.Stocks["MSFT"] = 2.0
-	portfolio.Stocks["GOOGL"] = 3.0
-	assert.Equal(t, 14.0, portfolio.MeanHighLowValue(window))
-}
-
-func TestNewBalancedCapitalDistribution(t *testing.T) {
-	distribution := NewBalancedCapitalDistribution(window.High)
-	assert.Equal(t, distribution.GetStock("MSFT"), 0.5)
-	assert.Equal(t, distribution.GetStock("GOOGL"), 0.5)
-}
-
-func TestCapitalDistributionGetSetStock(t *testing.T) {
-	distribution := NewCapitalDistribution()
-	distribution.SetStock("gravy", 1.0)
-	assert.Equal(t, 1.0, distribution.GetStock("gravy"))
-}
-
-func TestCapitalDistributionToAbstractPortfolioOnPrices(t *testing.T) {
-	distribution := NewBalancedCapitalDistribution(window.High)
-	portfolio := distribution.ToAbstractPortfolioOnPrices(window.High, 2.0)
-	assert.Equal(t, 1.0, window.High["MSFT"]*portfolio.Stocks["MSFT"])
-	assert.Equal(t, 1.0, window.High["GOOGL"]*portfolio.Stocks["GOOGL"])
-}
-
-func TestCapitalDistributionRelativeWindowPerformance(t *testing.T) {
-	// 4 shares msft, 3 shares googl
-	distribution := NewBalancedCapitalDistribution(window.Open)
-	total := (0.5)*(2.5-1.5)/1.5 + (0.5)*(3.5-2.5)/2.5
-	assert.Equal(t, total, distribution.RelativeWindowPerformance(window))
+	assert.Equal(t, uniform, cd)
+	assert.Equal(t, ap, ap2)
 }


### PR DESCRIPTION
Progress.

- Db exposes a NextDate to get the next valid trading date.
- Strategies can peek at the tickers on the next date in order to see what stocks they will invest in in the next cycle.
- Many more things lint.
- IPOs and Unlistings signals now report IPOs/Unlistings that will happen between date and NextDate(date).
- Added lots of unit tests.

This fixes a glaring issue wherein weekends/holidays were not accounted for and messing up everything. Numbers are looking much more reasonable now, however still not matching expectation. For example the "buy and hold" and "invest uniformly everyday" strategies perform like this:

![perf](https://user-images.githubusercontent.com/7853117/72694143-c75ff600-3ae8-11ea-9b9f-8a9e97e00c6e.png)

but the DOW and S&P for 1970 look like this:

<img width="828" alt="dow" src="https://user-images.githubusercontent.com/7853117/72694153-d0e95e00-3ae8-11ea-89e2-f1c2a0312db0.png">
