### PR TITLE
Readonly algo

### DIFF
--- a/algorithm/readonly/readonly.go
+++ b/algorithm/readonly/readonly.go
@@ -1,0 +1,92 @@
+package readonly
+
+import (
+	"context"
+	"fmt"
+
+	algorithmio_pb "github.com/d-sparks/gravy/algorithm/proto"
+	dailyprices_pb "github.com/d-sparks/gravy/data/dailyprices/proto"
+	"github.com/d-sparks/gravy/registrar"
+	supervisor_pb "github.com/d-sparks/gravy/supervisor/proto"
+	"github.com/golang/protobuf/ptypes"
+)
+
+// ReadOnly only reads data/prices and doesn't trade. Used for warming up the dbs.
+type ReadOnly struct {
+	algorithmio_pb.UnimplementedAlgorithmServer
+
+	// Algorithm ID (usually "readonly" unless multiple are running)
+	id          string
+	algorithmID *supervisor_pb.AlgorithmId
+	registrar   *registrar.R
+}
+
+// skipTrading is a precondition. Save time if you don't need to fetch prices/portfolio.
+func (b *ReadOnly) skipTrading() bool {
+	return false
+}
+
+// trade is the algorithm itself.
+func (b *ReadOnly) trade(
+	portfolio *supervisor_pb.Portfolio,
+	data *dailyprices_pb.DailyData,
+) []*supervisor_pb.Order {
+	return []*supervisor_pb.Order{}
+}
+
+// New creates a new, uninitialized ReadOnly algorithm.
+func New(algorithmID string) *ReadOnly {
+	return &ReadOnly{
+		id:          algorithmID,
+		algorithmID: &supervisor_pb.AlgorithmId{AlgorithmId: algorithmID},
+	}
+}
+
+// ******************************
+//  Mostly boilerplate hereafter
+// ******************************
+
+// Init initializes the registrar. The algorithm should be listening before calling Init to avoid deadlocks.
+func (b *ReadOnly) Init() error {
+	var err error
+	b.registrar, err = registrar.NewWithSupervisor()
+	return err
+}
+
+// Close closes the regitsrar.
+func (b *ReadOnly) Close() {
+	b.registrar.Close()
+}
+
+// Execute implements the algorithm interface.
+func (b *ReadOnly) Execute(ctx context.Context, input *algorithmio_pb.Input) (*algorithmio_pb.Output, error) {
+	fmt.Printf("Excuting algorithm on %s\n", ptypes.TimestampString(input.GetTimestamp()))
+	orders := []*supervisor_pb.Order{}
+
+	if !b.skipTrading() {
+		portfolio, err := b.registrar.Supervisor.GetPortfolio(ctx, b.algorithmID)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting portfolio in `%s`: %s", b.id, err.Error())
+		}
+
+		req := dailyprices_pb.Request{Timestamp: input.GetTimestamp(), Version: 0}
+		prices, err := b.registrar.DailyPrices.Get(ctx, &req)
+		if err != nil {
+			return nil, fmt.Errorf("Error getting daily prices in `%s`: %s", b.id, err.Error())
+		}
+
+		orders = b.trade(portfolio, prices)
+		for _, order := range orders {
+			if _, err := b.registrar.Supervisor.PlaceOrder(ctx, order); err != nil {
+				return nil, fmt.Errorf(
+					"Error placing order from `%s`: %s", b.id, err.Error(),
+				)
+			}
+		}
+	}
+	if _, err := b.registrar.Supervisor.DoneTrading(ctx, b.algorithmID); err != nil {
+		return nil, fmt.Errorf("Error calling DoneTrading from `%s`: %s", b.id, err.Error())
+	}
+
+	return &algorithmio_pb.Output{}, nil
+}

--- a/cmd/algorithm/readonly/main.go
+++ b/cmd/algorithm/readonly/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	algorithmio_pb "github.com/d-sparks/gravy/algorithm/proto"
+	"github.com/d-sparks/gravy/algorithm/readonly"
+	"google.golang.org/grpc"
+)
+
+var (
+	id   = flag.String("id", "readonly", "Algorithm ID.")
+	port = flag.Int("port", 17506, "Port for rpc server.")
+)
+
+func main() {
+	flag.Parse()
+
+	// Listen on tcp
+	listeningOn := fmt.Sprintf("localhost:%d", *port)
+	lis, err := net.Listen("tcp", listeningOn)
+	if err != nil {
+		log.Fatalf("Failed to listen over tcp: %s", err.Error())
+	}
+
+	// Make server (uninitialized)
+	algorithmServer := readonly.New(*id)
+
+	// Create grcp server and serve
+	var opts []grpc.ServerOption
+	grpcServer := grpc.NewServer(opts...)
+	algorithmio_pb.RegisterAlgorithmServer(grpcServer, algorithmServer)
+
+	// Init and serve.
+	algorithmServer.Init()
+	defer algorithmServer.Close()
+	log.Printf("Listening on `%s`", listeningOn)
+	grpcServer.Serve(lis)
+}

--- a/studies/next_port.sh
+++ b/studies/next_port.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git grep 175.. | grep "\.go" | grep -o "175[0-9][0-9]" | sort | uniq

--- a/studies/warmup_db.sh
+++ b/studies/warmup_db.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+trap "kill 0" EXIT
+
+OUTPUT_DIR=/tmp/readonlyfizz
+mkdir -p "${OUTPUT_DIR}"
+
+# Supervisor
+go run cmd/supervisor/main.go \
+  > "${OUTPUT_DIR}/supervisorstdout" &
+
+# Algorithms
+go run cmd/algorithm/readonly/main.go \
+  --id="readonly" \
+  --port=17506 \
+  > "${OUTPUT_DIR}/readonlyout" &
+
+# Run
+go run cmd/begin_backtest/main.go \
+  --start="2005-02-25" \
+  --end="2100-01-01" \
+  --output_dir="${OUTPUT_DIR}" \
+  --algorithms="readonly@localhost:17506"


### PR DESCRIPTION
Add a "next port" bash script and a warmup db study.

* Next port uses `git grep` to find all ports written in go files.
* warmup_db.sh calls a new `ReadOnly` strategy which simply reads the daily data to warmup the DB.